### PR TITLE
Fix conversion of shell script step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/infostretch/labs/plugins/Shell.java
+++ b/src/main/java/com/infostretch/labs/plugins/Shell.java
@@ -34,7 +34,7 @@ public class Shell extends Plugins {
 
     @Override
     public void transformBuild() {
-        appendBuildSteps("\t\t// Shell build step");
+        appendBuildSteps("\n\t\t// Shell build step");
         Element unstableReturn = getElementByTag("unstableReturn");
         String unstableValue = "";
         if (unstableReturn != null && unstableReturn.getTextContent() != null) {
@@ -47,9 +47,10 @@ public class Shell extends Plugins {
             command = "\n" + command;
         }
         if (unstableValue.length() > 0) {
-            appendBuildSteps("\n{ \n def shellReturnStatus = sh returnStatus: true, script: '''" + command + "\n'''\n if(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n}");
+            appendBuildSteps("\n\t\t{\n\t\t\tdef shellReturnStatus = sh returnStatus: true, script: '''" + command +
+                    "\n'''\n\t\t\tif(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n\t\t}");
         } else {
-            appendBuildSteps("\nsh '''" + command + " \n'''");
+            appendBuildSteps("\n\t\tsh '''" + command + " \n'''");
         }
     }
 }

--- a/src/main/java/com/infostretch/labs/plugins/Shell.java
+++ b/src/main/java/com/infostretch/labs/plugins/Shell.java
@@ -40,15 +40,15 @@ public class Shell extends Plugins {
         if (unstableReturn != null && unstableReturn.getTextContent() != null) {
             unstableValue = unstableReturn.getTextContent();
         }
+        String command = getElementByTag("command").getTextContent().trim();
+        // If the script has a shebang it needs to be on the first line so that the shell parses it
+        if (!command.startsWith("#!")) {
+            // Otherwise insert a newline to make the code more readable
+            command = "\n" + command;
+        }
         if (unstableValue.length() > 0) {
-            appendBuildSteps("\n{ \n def shellReturnStatus = sh returnStatus: true, script: \"\"\" \n" + getElementByTag("command").getTextContent().trim() + " \n \"\"\" \n if(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n}");
+            appendBuildSteps("\n{ \n def shellReturnStatus = sh returnStatus: true, script: '''" + command + "\n'''\n if(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n}");
         } else {
-            String command = getElementByTag("command").getTextContent().trim();
-            // If the script has a shebang it needs to be on the first line so that the shell parses it
-            if (!command.startsWith("#!")) {
-                // Otherwise insert a newline to make the code more readable
-                command = "\n" + command;
-            }
             appendBuildSteps("\nsh '''" + command + " \n'''");
         }
     }

--- a/src/main/java/com/infostretch/labs/plugins/Shell.java
+++ b/src/main/java/com/infostretch/labs/plugins/Shell.java
@@ -43,7 +43,13 @@ public class Shell extends Plugins {
         if (unstableValue.length() > 0) {
             appendBuildSteps("\n{ \n def shellReturnStatus = sh returnStatus: true, script: \"\"\" \n" + getElementByTag("command").getTextContent().trim() + " \n \"\"\" \n if(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n}");
         } else {
-            appendBuildSteps("\nsh '''\n" + getElementByTag("command").getTextContent().trim() + " \n'''");
+            String command = getElementByTag("command").getTextContent().trim();
+            // If the script has a shebang it needs to be on the first line so that the shell parses it
+            if (!command.startsWith("#!")) {
+                // Otherwise insert a newline to make the code more readable
+                command = "\n" + command;
+            }
+            appendBuildSteps("\nsh '''" + command + " \n'''");
         }
     }
 }

--- a/src/main/java/com/infostretch/labs/plugins/Shell.java
+++ b/src/main/java/com/infostretch/labs/plugins/Shell.java
@@ -43,7 +43,7 @@ public class Shell extends Plugins {
         if (unstableValue.length() > 0) {
             appendBuildSteps("\n{ \n def shellReturnStatus = sh returnStatus: true, script: \"\"\" \n" + getElementByTag("command").getTextContent().trim() + " \n \"\"\" \n if(shellReturnStatus == " + unstableValue + ") { currentBuild.result = 'UNSTABLE' } \n}");
         } else {
-            appendBuildSteps("\nsh \"\"\" \n" + getElementByTag("command").getTextContent().trim() + " \n \"\"\"");
+            appendBuildSteps("\nsh '''\n" + getElementByTag("command").getTextContent().trim() + " \n'''");
         }
     }
 }

--- a/src/main/java/com/infostretch/labs/transformers/Transformer.java
+++ b/src/main/java/com/infostretch/labs/transformers/Transformer.java
@@ -27,6 +27,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -35,10 +36,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -80,13 +78,30 @@ public class Transformer {
      * Initialises transformation process of Freestyle project to Pipeline.
      */
     public void performFreeStyleTransformation() {
+        initializeConversion();
+        transformJob((FreeStyleProject) requestParams.get("initialProject"), (boolean)requestParams.get("downStream"));
+        finalizeConversion((boolean) requestParams.get("commitJenkinsfile"), requestParams.get("commitMessage").toString());
+        logger.info("Completed conversion of all jobs");
+    }
+
+    /** For testing pureposes */
+    public String transformXml(Document doc, String jobName) throws ParserConfigurationException {
+        initializeConversion();
+        this.doc = doc;
+        this.currentJobName = jobName;
+        transformDocument();
+        finalizeConversion(false, "");
+        return script.toString();
+    }
+
+    private void initializeConversion() {
         appendToScript("// Powered by Infostretch \n\n");
         appendToScript("timestamps {\n");
-        transformJob((FreeStyleProject) requestParams.get("initialProject"), (boolean)requestParams.get("downStream"));
+    }
+    private void finalizeConversion(boolean commitJenkinsfile, String commitMessage) {
         appendToScript("\n}\n}");
-        appendScriptToXML((boolean) requestParams.get("commitJenkinsfile"), requestParams.get("commitMessage").toString());
+        appendScriptToXML(commitJenkinsfile, commitMessage);
         writeConfiguration();
-        logger.info("Completed conversion of all jobs");
     }
 
     /**
@@ -100,11 +115,7 @@ public class Transformer {
         try {
             currentJobName = item.getFullName();
             doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(item.getConfigFile().getFile());
-            dest = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-            flowDefinition = dest.createElement("flow-definition");
-            dest.appendChild(flowDefinition);
-            doc.getDocumentElement().normalize();
-            transformFile();
+            transformDocument();
             if (downStream) {
                 for (Item job : item.getDownstreamProjects()) {
                     if (job instanceof FreeStyleProject) {
@@ -116,6 +127,14 @@ public class Transformer {
         } catch (Exception e) {
             logger.severe("Exception occurred in Transformer constructor: " + e.getMessage());
         }
+    }
+
+    protected void transformDocument() throws ParserConfigurationException {
+        dest = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        flowDefinition = dest.createElement("flow-definition");
+        dest.appendChild(flowDefinition);
+        doc.getDocumentElement().normalize();
+        transformFile();
     }
 
     /**

--- a/src/test/java/com/infostretch/labs/plugins/ShellTest.java
+++ b/src/test/java/com/infostretch/labs/plugins/ShellTest.java
@@ -27,7 +27,7 @@ public class ShellTest {
 
     @Test
     public void transformBuild() {
-        String expectedConversion = "sh '''#!/bin/bash\n" +
+        String expectedConversion = "\t\tsh '''#!/bin/bash\n" +
                 "shell_var=123\n" +
                 "other_var=${shell_var}  # this should not be expanded by groovy! \n" +
                 "'''";
@@ -36,10 +36,10 @@ public class ShellTest {
 
     @Test
     public void transformBuildWithUnstable() {
-        String expectedConversion = "def shellReturnStatus = sh returnStatus: true, script: '''#!/bin/bash\n" +
+        String expectedConversion = "\t\t\tdef shellReturnStatus = sh returnStatus: true, script: '''#!/bin/bash\n" +
                 "echo ${var}\n" +
                 "'''\n" +
-                " if(shellReturnStatus == 2) { currentBuild.result = 'UNSTABLE' } ";
+                "\t\t\tif(shellReturnStatus == 2) { currentBuild.result = 'UNSTABLE' } ";
         assertThat(convertJob("../../../../xml/shell-script-unstable-return.xml"), containsString(expectedConversion));
     }
 }

--- a/src/test/java/com/infostretch/labs/plugins/ShellTest.java
+++ b/src/test/java/com/infostretch/labs/plugins/ShellTest.java
@@ -1,0 +1,45 @@
+package com.infostretch.labs.plugins;
+
+import com.infostretch.labs.transformers.Transformer;
+import org.junit.Test;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ShellTest {
+
+    private String convertJob(String xmlPath) {
+        InputStream is = null;
+        try {
+            is = getClass().getResource(xmlPath).openStream();
+            Transformer t = new Transformer(new HashMap());
+            String script = t.transformXml(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is), "test");
+            System.out.println(script);
+            return script;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void transformBuild() {
+        String expectedConversion = "sh '''#!/bin/bash\n" +
+                "shell_var=123\n" +
+                "other_var=${shell_var}  # this should not be expanded by groovy! \n" +
+                "'''";
+        assertThat(convertJob("../../../../xml/shell-script-simple.xml"), containsString(expectedConversion));
+    }
+
+    @Test
+    public void transformBuildWithUnstable() {
+        String expectedConversion = "def shellReturnStatus = sh returnStatus: true, script: '''#!/bin/bash\n" +
+                "echo ${var}\n" +
+                "'''\n" +
+                " if(shellReturnStatus == 2) { currentBuild.result = 'UNSTABLE' } ";
+        assertThat(convertJob("../../../../xml/shell-script-unstable-return.xml"), containsString(expectedConversion));
+    }
+}

--- a/src/test/resources/xml/shell-script-simple.xml
+++ b/src/test/resources/xml/shell-script-simple.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties></properties>
+    <assignedNode>linux</assignedNode>
+    <canRoam>false</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers></triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <!-- The shebang should always be the first thing in the resulting shell script-->
+            <command>#!/bin/bash
+shell_var=123
+other_var=${shell_var}  # this should not be expanded by groovy!
+            </command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers></publishers>
+    <buildWrappers></buildWrappers>
+</project>

--- a/src/test/resources/xml/shell-script-unstable-return.xml
+++ b/src/test/resources/xml/shell-script-unstable-return.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties></properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>#!/bin/bash
+echo ${var}
+            </command>
+            <unstableReturn>2</unstableReturn>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
Currently the sh step uses `"""` so groovy attempt to expand any `${FOO}` variables but they should actually be parsed by the shell instead. To fix this I changed it to use a `'''` string.
Also inserting a newline before the script contents will break any `#!` interpreter selection. I fixed this by only adding a newline if the script doesn't start with `#!`