### PR TITLE
Handle additional plugins / fix plugin handling

### DIFF
--- a/src/main/java/com/infostretch/labs/plugins/ExtendedEmailPublisher.java
+++ b/src/main/java/com/infostretch/labs/plugins/ExtendedEmailPublisher.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright 2018 ...
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+ *
+ * You should have received a copy of the GNU General Public License along with this program in the name of LICENSE.txt in the root folder of the distribution. If not, see https://opensource.org/licenses/gpl-3.0.html
+ *
+ *
+ * For any inquiry or need additional information, please contact labs_support@infostretch.com
+ *******************************************************************************/
+
+package com.infostretch.labs.plugins;
+
+import com.infostretch.labs.transformers.PublisherTransformer;
+import com.infostretch.labs.transformers.Transformer;
+import org.w3c.dom.Node;
+
+/**
+ * Handles transformation of ExtendedEmailPublisher Plugin properties
+ *
+ * @author ...
+ */
+public class ExtendedEmailPublisher extends Plugins {
+
+    public ExtendedEmailPublisher(Transformer transformer, Node node) {
+        super(transformer, node);
+    }
+
+    @Override
+    public void transformPublisher() {
+        transformer.setOnlyBuildTrigger(false);
+        appendPublishSteps("\n\t\t// ExtendedEmailPublisher notification");
+        appendPublishSteps("\n\t\tstep([$class: 'emailext'" +
+            ", attachLog: " + Boolean.valueOf(getElementByTag("attachBuildLog").getTextContent()) +
+            ", attachmentsPattern: " + getElementByTag("attachmentsPattern").getTextContent() +
+            ", defaultContent: " + getElementByTag("body").getTextContent() +
+            ", compressLog: " + Boolean.valueOf(getElementByTag("compressBuildLog").getTextContent()) +
+            ", mimeType: " + getElementByTag("contentType").getTextContent() +
+            ", postsendScript: " + getElementByTag("postsendScript").getTextContent() +
+            ", presendScript: " + getElementByTag("presendScript").getTextContent() +
+            ", replyTo: " + getElementByTag("replyTo").getTextContent() +
+            ", subject: " + getElementByTag("subject").getTextContent() +
+            ", to: " + getElementByTag("recipientList").getTextContent() +
+            "])\n");
+    }
+}

--- a/src/main/java/com/infostretch/labs/plugins/SecretBuildWrapper.java
+++ b/src/main/java/com/infostretch/labs/plugins/SecretBuildWrapper.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright 2018 ...
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+ *
+ * You should have received a copy of the GNU General Public License along with this program in the name of LICENSE.txt in the root folder of the distribution. If not, see https://opensource.org/licenses/gpl-3.0.html
+ *
+ *
+ * For any inquiry or need additional information, please contact labs_support@infostretch.com
+ *******************************************************************************/
+
+package com.infostretch.labs.plugins;
+
+import com.infostretch.labs.transformers.Transformer;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Handles transformation of SecretBuildWrapper Plugin properties
+ *
+ * @author ...
+ */
+public class SecretBuildWrapper extends Plugins {
+    static final String credentialsbindingimpl = "org.jenkinsci.plugins.credentialsbinding.impl.";
+    static final String dockerbindingimpl = "org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentialsBinding";
+
+    public SecretBuildWrapper(Transformer transformer, Node node) {
+        super(transformer, node);
+    }
+
+    @Override
+    public void transformBuild() {
+        List<String> creds = new ArrayList<String>();
+        NodeList bindings = getElementByTag("bindings").getChildNodes();
+        for (int i=0; i < bindings.getLength(); i++) {
+            Node binding = bindings.item(i);
+            String nodeName = binding.getNodeName();
+            String converted;
+            if (nodeName.startsWith(credentialsbindingimpl)) {
+                String impl = nodeName.substring(credentialsbindingimpl.length());
+                switch (impl) {
+                    case "StringBinding":
+                        converted = "string(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", variable: " + getElementByTag(binding, "variable").getTextContent() +
+                                    ")";
+                        break;
+                    case "UsernamePasswordBinding":
+                        converted = "usernameColonPassword(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", variable: " + getElementByTag(binding, "variable").getTextContent() +
+                                    ")";
+                        break;
+                    case "FileBinding":
+                        converted = "file(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", variable: " + getElementByTag(binding, "variable").getTextContent() +
+                                    ")";
+                        break;
+                    case "ZipFileBinding":
+                        converted = "zip(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", variable: " + getElementByTag(binding, "variable").getTextContent() +
+                                    ")";
+                        break;
+                    case "SSHUserPrivateKeyBinding":
+                        converted = "sshUserPrivateKey(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", keyFileVariable: " + getElementByTag(binding, "keyFileVariable").getTextContent() +
+                                    ", passphraseVariable: " + getElementByTag(binding, "passphraseVariable").getTextContent() +
+                                    ", usernameVariable: " + getElementByTag(binding, "usernameVariable").getTextContent() +
+                                    ")";
+                        break;
+                    case "UsernamePasswordMultiBinding":
+                        converted = "usernamePassword(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", passwordVariable: " + getElementByTag(binding, "passwordVariable").getTextContent() +
+                                    ", usernameVariable: " + getElementByTag(binding, "usernameVariable").getTextContent() +
+                                    ")";
+                        break;
+                    case "CertificateMultiBinding":
+                        converted = "certificate(" +
+                                      "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                                    ", aliasVariable: " + getElementByTag(binding, "aliasVariable").getTextContent() +
+                                    ", keystoreVariable: " + getElementByTag(binding, "keystoreVariable").getTextContent() +
+                                    ", passwordVariable: " + getElementByTag(binding, "passwordVariable").getTextContent() +
+                                    ")";
+                        break;
+                    default:
+                        converted = "/* unhandled basic type: " + impl + "*/";
+                }
+            } else if (nodeName.equals(dockerbindingimpl)) {
+                converted = "dockerCert(" +
+                              "credentialsId: " + getElementByTag(binding, "credentialsId").getTextContent() +
+                            ", variable: " + getElementByTag(binding, "variable").getTextContent() +
+                            ")";
+            } else {
+                converted = "/* unhandled type: " + nodeName + "*/";
+            }
+            creds.add(converted);
+        }
+
+        appendBuildSteps("\t\t// SecretBuildWrapper -- some assembly required");
+        appendBuildSteps("\nwithCredentials([" + creds.toString() +
+            "]) {\n" +
+            "\t\t\t// please move build block here\n" +
+            "}\n");
+    }
+}

--- a/src/main/java/com/infostretch/labs/plugins/TimestamperBuildWrapper.java
+++ b/src/main/java/com/infostretch/labs/plugins/TimestamperBuildWrapper.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2018 ...
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+ *
+ * You should have received a copy of the GNU General Public License along with this program in the name of LICENSE.txt in the root folder of the distribution. If not, see https://opensource.org/licenses/gpl-3.0.html
+ *
+ *
+ * For any inquiry or need additional information, please contact labs_support@infostretch.com
+ *******************************************************************************/
+
+package com.infostretch.labs.plugins;
+
+import com.infostretch.labs.transformers.Transformer;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * Handles transformation of TimestamperBuildWrapper properties
+ *
+ * @author ...
+ */
+public class TimestamperBuildWrapper extends Plugins {
+
+    public TimestamperBuildWrapper(Transformer transformer, Node node) {
+        super(transformer, node);
+    }
+
+}

--- a/src/main/java/com/infostretch/labs/transformers/Transformer.java
+++ b/src/main/java/com/infostretch/labs/transformers/Transformer.java
@@ -84,7 +84,16 @@ public class Transformer {
         logger.info("Completed conversion of all jobs");
     }
 
-    /** For testing pureposes */
+    /**
+     * For testing purposes
+     *
+     * @param doc Document to convert
+     * @param jobName name of job
+     *
+     * @return string converted document as string
+     *
+     * @throws ParserConfigurationException
+     */
     public String transformXml(Document doc, String jobName) throws ParserConfigurationException {
         initializeConversion();
         this.doc = doc;
@@ -96,10 +105,9 @@ public class Transformer {
 
     private void initializeConversion() {
         appendToScript("// Powered by Infostretch \n\n");
-        appendToScript("timestamps {\n");
     }
     private void finalizeConversion(boolean commitJenkinsfile, String commitMessage) {
-        appendToScript("\n}\n}");
+        appendToScript("\n}");
         appendScriptToXML(commitJenkinsfile, commitMessage);
         writeConfiguration();
     }
@@ -130,11 +138,18 @@ public class Transformer {
     }
 
     protected void transformDocument() throws ParserConfigurationException {
+        boolean timestamps = doc.getElementsByTagName("hudson.plugins.timestamper.TimestamperBuildWrapper").getLength() != 0;
+        if (timestamps) {
+            appendToScript("timestamps {\n");
+        }
         dest = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         flowDefinition = dest.createElement("flow-definition");
         dest.appendChild(flowDefinition);
         doc.getDocumentElement().normalize();
         transformFile();
+        if (timestamps) {
+            appendToScript("\n}");
+        }
     }
 
     /**

--- a/src/main/java/com/infostretch/labs/utils/PluginClass.java
+++ b/src/main/java/com/infostretch/labs/utils/PluginClass.java
@@ -26,7 +26,8 @@ public enum PluginClass {
 
     TestNG("hudson.plugins.testng.Publisher"),
     Git("hudson.plugins.git.GitSCM"),
-    ExtendedEmailPublisher("hudson.plugins.emailext.ExtendedEmailPublisher");
+    ExtendedEmailPublisher("hudson.plugins.emailext.ExtendedEmailPublisher"),
+    SecretBuildWrapper("org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper");
 
     private String nodeTag;
 

--- a/src/main/java/com/infostretch/labs/utils/PluginClass.java
+++ b/src/main/java/com/infostretch/labs/utils/PluginClass.java
@@ -25,7 +25,8 @@ package com.infostretch.labs.utils;
 public enum PluginClass {
 
     TestNG("hudson.plugins.testng.Publisher"),
-    Git("hudson.plugins.git.GitSCM");
+    Git("hudson.plugins.git.GitSCM"),
+    ExtendedEmailPublisher("hudson.plugins.emailext.ExtendedEmailPublisher");
 
     private String nodeTag;
 

--- a/src/test/java/com/infostretch/labs/actions/ConvertJobActionTest.java
+++ b/src/test/java/com/infostretch/labs/actions/ConvertJobActionTest.java
@@ -28,7 +28,7 @@ public class ConvertJobActionTest {
 
     @Test
     public void transformBuild() {
-        String expectedConversion = "// Powered by Infostretch timestamps { node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' } } }";
+        String expectedConversion = "// Powered by Infostretch node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' } }";
         expectedConversion = expectedConversion.replaceAll("\\s","");
         assertThat(convertJob("../../../../xml/freestyle-config.xml"), containsString(expectedConversion));
     }

--- a/src/test/java/com/infostretch/labs/actions/ConvertMailJobActionTest.java
+++ b/src/test/java/com/infostretch/labs/actions/ConvertMailJobActionTest.java
@@ -1,0 +1,43 @@
+package com.infostretch.labs.actions;
+
+import com.infostretch.labs.transformers.Transformer;
+import org.junit.Test;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ConvertMailJobActionTest {
+
+    private String convertJob(String xmlPath) {
+        InputStream is = null;
+        try {
+            is = getClass().getResource(xmlPath).openStream();
+            Transformer t = new Transformer(new HashMap());
+            String script = t.transformXml(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is), "test");
+            script = script.replaceAll("\\s","");
+            System.out.println(script);
+            return script;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void transformBuild() {
+        String expectedConversion = "// Powered by Infostretch node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' }\n"
+                                  + "stage ('test - Postbuild actions') {"
+                                  + "\n/*\nPlease note this is a direct conversion of post-build actions. It may not necessarily work/behave in the same way as post-build actions work. A logic review is suggested.\n*/"
+                                  + "\n\t\t// ExtendedEmailPublisher notification"
+                                  + "\n} }";
+        // XXX This is not the right end result...
+
+        expectedConversion = expectedConversion.replaceAll("\\s","");
+        String result = convertJob("../../../../xml/mail-freestyle-config.xml");
+        System.out.println(result);
+        assertThat(convertJob("../../../../xml/mail-freestyle-config.xml"), containsString(expectedConversion));
+    }
+}

--- a/src/test/java/com/infostretch/labs/actions/ConvertRootActionTest.java
+++ b/src/test/java/com/infostretch/labs/actions/ConvertRootActionTest.java
@@ -27,7 +27,7 @@ public class ConvertRootActionTest {
 
     @Test
     public void transformBuild() {
-        String expectedConversion = "// Powered by Infostretch timestamps { node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' } } }";
+        String expectedConversion = "// Powered by Infostretch node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' } }";
         expectedConversion = expectedConversion.replaceAll("\\s","");
         assertThat(convertJob("../../../../xml/freestyle-config.xml"), containsString(expectedConversion));
     }

--- a/src/test/java/com/infostretch/labs/actions/ConvertSecretJobActionTest.java
+++ b/src/test/java/com/infostretch/labs/actions/ConvertSecretJobActionTest.java
@@ -1,0 +1,43 @@
+package com.infostretch.labs.actions;
+
+import com.infostretch.labs.transformers.Transformer;
+import org.junit.Test;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ConvertSecretJobActionTest {
+
+    private String convertJob(String xmlPath) {
+        InputStream is = null;
+        try {
+            is = getClass().getResource(xmlPath).openStream();
+            Transformer t = new Transformer(new HashMap());
+            String script = t.transformXml(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is), "test");
+            script = script.replaceAll("\\s","");
+            System.out.println(script);
+            return script;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void transformBuild() {
+        String expectedConversion = "// Powered by Infostretch node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' }\n"
+                                  + "stage ('test - Postbuild actions') {"
+                                  + "\n/*\nPlease note this is a direct conversion of post-build actions. It may not necessarily work/behave in the same way as post-build actions work. A logic review is suggested.\n*/"
+                                  + "\n\t\t// ExtendedEmailPublisher notification"
+                                  + "\n} }";
+        // XXX This is not the right end result...
+
+        expectedConversion = expectedConversion.replaceAll("\\s","");
+        String result = convertJob("../../../../xml/secret-freestyle-config.xml");
+        System.out.println(result);
+        assertThat(convertJob("../../../../xml/secret-freestyle-config.xml"), containsString(expectedConversion));
+    }
+}

--- a/src/test/java/com/infostretch/labs/actions/ConvertTimestampJobActionTest.java
+++ b/src/test/java/com/infostretch/labs/actions/ConvertTimestampJobActionTest.java
@@ -10,13 +10,14 @@ import java.util.HashMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
-public class ConvertFolderActionTest {
+public class ConvertTimestampJobActionTest {
+
     private String convertJob(String xmlPath) {
         InputStream is = null;
         try {
             is = getClass().getResource(xmlPath).openStream();
             Transformer t = new Transformer(new HashMap());
-            String script = t.transformXml(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is), "testfolder/test");
+            String script = t.transformXml(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is), "test");
             script = script.replaceAll("\\s","");
             System.out.println(script);
             return script;
@@ -27,8 +28,8 @@ public class ConvertFolderActionTest {
 
     @Test
     public void transformBuild() {
-        String expectedConversion = "// Powered by Infostretch node () { stage ('testfolder/test - Build') { // Shell build step sh ''' echo \"hello\" ''' } }";
+        String expectedConversion = "// Powered by Infostretch timestamps { node () { stage ('test - Build') { // Shell build step sh ''' echo \"hello\" ''' } } }";
         expectedConversion = expectedConversion.replaceAll("\\s","");
-        assertThat(convertJob("../../../../xml/folder-freestyle-config.xml"), containsString(expectedConversion));
+        assertThat(convertJob("../../../../xml/timestamp-freestyle-config.xml"), containsString(expectedConversion));
     }
 }

--- a/src/test/resources/xml/mail-freestyle-config.xml
+++ b/src/test/resources/xml/mail-freestyle-config.xml
@@ -1,0 +1,34 @@
+<project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>echo "hello"</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers>
+      <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.37.2">
+        <recipientList>recipient@example.com</recipientList>
+        <contentType>default</contentType>
+        <defaultSubject>default-subject</defaultSubject>
+        <defaultContent>default-content</defaultContent>
+        <attachmentsPattern>*.log</attachmentsPattern>
+        <presendScript>try {(void)"presend";true;} catch (all) {}</presendScript>
+        <postsendScript>>try {(void)"postsend";true;} catch (all) {}</postsendScript>
+        <attachBuildLog>false</attachBuildLog>
+        <compressBuildLog>false</compressBuildLog>
+        <replyTo>replyto@example.com</replyTo>
+        <saveOutput>false</saveOutput>
+      </hudson.plugins.emailext.ExtendedEmailPublisher>
+    </publishers>
+    <buildWrappers/>
+</project>

--- a/src/test/resources/xml/secret-freestyle-config.xml
+++ b/src/test/resources/xml/secret-freestyle-config.xml
@@ -1,0 +1,57 @@
+<project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>echo "hello"</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers>
+      <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.13">
+        <bindings>
+          <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+            <credentialsId>sshkeyid</credentialsId>
+            <keyFileVariable>SSH_KEY</keyFileVariable>
+            <usernameVariable>USERNAME</usernameVariable>
+            <passphraseVariable>PASSPHRASE</passphraseVariable>
+          </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+          <org.jenkinsci.plugins.credentialsbinding.impl.ZipFileBinding>
+            <variable>CONFIG_ZIP</variable>
+            <credentialsId>zipid</credentialsId>
+          </org.jenkinsci.plugins.credentialsbinding.impl.ZipFileBinding>
+          <org.jenkinsci.plugins.credentialsbinding.impl.FileBinding>
+            <variable>config_file</variable>
+            <credentialsId>fileid</credentialsId>
+          </org.jenkinsci.plugins.credentialsbinding.impl.FileBinding>
+          <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordBinding>
+            <variable>config_username_password</variable>
+            <credentialsId>usernamepasswordid</credentialsId>
+          </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordBinding>
+          <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+            <variable>config_text</variable>
+            <credentialsId>stringid</credentialsId>
+          </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+          <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+            <usernameVariable>myUsername</usernameVariable>
+            <passwordVariable>myPassword</passwordVariable>
+            <credentialsId>usernamepasswordmultiid</credentialsId>
+          </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+          <com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding>
+            <accessKeyVariable>AWS_ACCESS_KEY_ID</accessKeyVariable>
+            <secretKeyVariable>AWS_SECRET_ACCESS_KEY</secretKeyVariable>
+            <credentialsId>awssecretid</credentialsId>
+          </com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding>
+        </bindings>
+      </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
+    </buildWrappers>
+</project>

--- a/src/test/resources/xml/timestamp-freestyle-config.xml
+++ b/src/test/resources/xml/timestamp-freestyle-config.xml
@@ -1,0 +1,22 @@
+<project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>echo "hello"</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers>
+        <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.9"/>
+    </buildWrappers>
+</project>


### PR DESCRIPTION
There are a number of (fairly basic) features of Jenkins that we use which aren't handled by convert-to-pipeline-plugin. It'd be nice if it supported them.

1. While compatibility.md claims that it handles timestamps, it doesn't actually suppress the "unhandled plugin" warning. And in fact, it appears to unconditionally add timestamps.
1. extendedemail -- I think I have the Jenkinsfile syntax wrong for this one.
1. Secrets

* The way timestamp and secrets work, it'd be nice if plugins had the option of being called to wrap a document (with the document) instead of only midstream to a document. -- I'm not trying to fix that today, but it's worth noting.

I created this PR early because I was curious to see if you had an autobuilder and I'd like feedback on the direction.